### PR TITLE
Added aspect ratio option for dials

### DIFF
--- a/css/newtab.css
+++ b/css/newtab.css
@@ -177,7 +177,7 @@ td {
 
 #breadcrumbs > div > a:last-child:hover {
 	background: none;
-	box-shadow: 0;
+	box-shadow: none;
 }
 
 #breadcrumbs > div > span {

--- a/css/newtab.css
+++ b/css/newtab.css
@@ -9,7 +9,7 @@ body {
 	text-align: center;
 }
 
-#dial {
+.innerBlock {
 	display: inline-block;
 }
 
@@ -142,4 +142,46 @@ td {
 	margin: 20px auto 10px auto;
 	min-width: 20em;
 	max-width: 30%;
+}
+
+#breadcrumbs > div {
+	float: left;
+	padding: 0 0.5em;
+}
+
+#breadcrumbs > div > * {
+	display: inline-block;
+	padding: 0.5em 0.7em;
+}
+
+#breadcrumbs > div > a {
+	color: inherit;
+	font-weight: bold;
+	text-decoration: none;
+	transition: background 0.3s, box-shadow 0.3s;
+}
+
+#breadcrumbs > div > a:hover {
+	background: rgba(0,0,0,0.1);
+	box-shadow: 0 0 5px rgba(0,0,0, 0.1);
+}
+
+#breadcrumbs > div > a:first-child {
+	vertical-align: sub;
+}
+
+#breadcrumbs > div > a:last-child {
+	cursor: default;
+	font-weight: inherit;
+}
+
+#breadcrumbs > div > a:last-child:hover {
+	background: none;
+	box-shadow: 0;
+}
+
+#breadcrumbs > div > span {
+	cursor: default;
+	padding-left: 0;
+	padding-right: 0;
 }

--- a/css/newtab.css
+++ b/css/newtab.css
@@ -19,8 +19,7 @@ body {
 }
 
 .entry:hover {
-	border: 7px solid rgba(53, 191, 256, 0.5);
-	border-radius: 12px;
+
 }
 
 .bookmark {
@@ -31,10 +30,12 @@ body {
 	height: 100%;
 	width: 100%;
 	text-decoration: none;
+	transition: box-shadow 0.15s
 }
 
 .entry .bookmark:hover {
 	color: #444;
+	box-shadow: 1px 1px 14px #666;
 }
 
 .image {
@@ -56,6 +57,7 @@ body {
 
 td {
 	opacity: 0.6;
+	transition: opacity 0.15s;
 }
 
 .edit, .remove {
@@ -81,7 +83,7 @@ td {
 	overflow: hidden;
 }
 
-.entry:hover .title {
+.bookmark:hover .title {
 	opacity: 0.9;
 }
 

--- a/css/options.css
+++ b/css/options.css
@@ -48,6 +48,12 @@ td {
 	float: left;
 }
 
+.form span {
+	display: inline-block;
+	float: left;
+	padding: 0.2em 1em 0 1em;
+}
+
 .form p {
 	margin: 0;
 	padding: 3px 0;

--- a/javascript/common.js
+++ b/javascript/common.js
@@ -53,6 +53,8 @@ function getStartingFolder() {
 // Create default localStorage values if they don't already exist
 function createDefaults() {
 	var default_values = {
+		aspect_ratio_h: 4,
+		aspect_ratio_v: 3,
 		background_color: "#cccccc",
 		custom_icon_data: "{}",
 		center_vertically: "true",

--- a/javascript/newtab.js
+++ b/javascript/newtab.js
@@ -84,12 +84,12 @@ function setDialStyles() {
 	// Set the values through CSS, rather than explicit individual CSS styles
 	// Height values are dictated by the aspectRatioInv
 	$("#styles").html(
-		"#dial { width:" + (adjustedDialWidth | 0) + "px; } " +
+		".innerBlock { width:" + (adjustedDialWidth | 0) + "px; } " +
 		".entry { height:" + ((entryHeight | 0) + 20) + "px; width:" + (entryWidth | 0) + "px; } " +
 		"td.title { max-width:" + (entryWidth - 50 | 0) + "px; } " +
 		".image { height:" + ((entryHeight) | 0) + "px; } " +
-		".foundicon-folder { font-size:" + (entryHeight * 0.67 | 0) + "px; top:" + (entryHeight * 0.067 | 0) + "px; color:" + folderColor + " } " +
-		".foundicon-plus { font-size:" + (entryHeight * 0.4 | 0) + "px; top:" + (entryHeight * 0.33 | 0) + "px; } "
+		".entry .foundicon-folder { font-size:" + (entryHeight * 0.67 | 0) + "px; top:" + (entryHeight * 0.067 | 0) + "px; color:" + folderColor + " } " +
+		".entry .foundicon-plus { font-size:" + (entryHeight * 0.4 | 0) + "px; top:" + (entryHeight * 0.33 | 0) + "px; } "
 	);
 }
 
@@ -131,6 +131,8 @@ function createSpeedDial(folderId) {
 			});
 		}
 	});
+
+	generateBreadcrumbs();
 }
 
 function getThumbnailUrl(bookmark) {
@@ -195,11 +197,15 @@ function updateCustomIcon(url, old_url) {
 function alignVertical() {
 	if (localStorage.getItem("center_vertically") === "true") {
 		var dial = $("#dial");
+		var paddingTop = (window.innerHeight - dial.height()) / 2 | 0;
+
 		if (localStorage.getItem("show_folder_list") === "true") {
-			dial.css("padding-top", ((window.innerHeight - dial.height()) / 2) - 50 | 0);
-		} else {
-			dial.css("padding-top", (window.innerHeight - dial.height()) / 2 | 0);
+			paddingTop-=50;
 		}
+		if (localStorage.getItem("show-breadcrumbs") === "true") {
+			paddingTop-=20;
+		}
+		dial.css("padding-top", paddingTop);
 	}
 }
 

--- a/javascript/newtab.js
+++ b/javascript/newtab.js
@@ -74,20 +74,22 @@ function setDialStyles() {
 	var borderWidth = 14;
 	var minEntryWidth = 120 - borderWidth;
 	var entryWidth = (adjustedDialWidth / dialColumns) - borderWidth;
+	var aspectRatioInv = parseFloat(localStorage.getItem("aspect_ratio_v")) / parseFloat(localStorage.getItem("aspect_ratio_h"));
+	var entryHeight = entryWidth * aspectRatioInv;
 
 	if (entryWidth < minEntryWidth) {
 		entryWidth = minEntryWidth;
 	}
 
 	// Set the values through CSS, rather than explicit individual CSS styles
-	// Height values are 3/4 or * 0.75 width values
+	// Height values are dictated by the aspectRatioInv
 	$("#styles").html(
 		"#dial { width:" + (adjustedDialWidth | 0) + "px; } " +
-		".entry { height:" + (entryWidth * 0.75 | 0) + "px; width:" + (entryWidth | 0) + "px; } " +
+		".entry { height:" + ((entryHeight | 0) + 20) + "px; width:" + (entryWidth | 0) + "px; } " +
 		"td.title { max-width:" + (entryWidth - 50 | 0) + "px; } " +
-		".image { height:" + ((entryWidth * 0.75) - 20 | 0) + "px; } " +
-		".foundicon-folder { font-size:" + (entryWidth * 0.5 | 0) + "px; top:" + (entryWidth * 0.05 | 0) + "px; color:" + folderColor + " } " +
-		".foundicon-plus { font-size:" + (entryWidth * 0.3 | 0) + "px; top:" + (entryWidth * 0.18 | 0) + "px; } "
+		".image { height:" + ((entryHeight) | 0) + "px; } " +
+		".foundicon-folder { font-size:" + (entryHeight * 0.67 | 0) + "px; top:" + (entryHeight * 0.067 | 0) + "px; color:" + folderColor + " } " +
+		".foundicon-plus { font-size:" + (entryHeight * 0.4 | 0) + "px; top:" + (entryHeight * 0.33 | 0) + "px; } "
 	);
 }
 

--- a/javascript/options.js
+++ b/javascript/options.js
@@ -13,6 +13,7 @@ function restoreOptions() {
 	$("#folder_color").prop("value", localStorage.getItem("folder_color"));
 	$("#force_http").prop("checked", localStorage.getItem("force_http") === "true");
 	$("#show_advanced").prop("checked", localStorage.getItem("show_advanced") === "true");
+	$("#show_breadcrumbs").prop("checked", localStorage.getItem("show_breadcrumbs") === "true");
 	$("#show_folder_list").prop("checked", localStorage.getItem("show_folder_list") === "true");
 	$("#show_new_entry").prop("checked", localStorage.getItem("show_new_entry") === "true");
 	$("#show_options_gear").prop("checked", localStorage.getItem("show_options_gear") === "true");
@@ -35,6 +36,7 @@ function saveOptions() {
 	localStorage.setItem("folder_color", $("#folder_color").prop("value"));
 	localStorage.setItem("force_http", $("#force_http").prop("checked"));
 	localStorage.setItem("show_advanced", $("#show_advanced").prop("checked"));
+	localStorage.setItem("show_breadcrumbs", $("#show_breadcrumbs").prop("checked"));
 	localStorage.setItem("show_folder_list", $("#show_folder_list").prop("checked"));
 	localStorage.setItem("show_new_entry", $("#show_new_entry").prop("checked"));
 	localStorage.setItem("show_options_gear", $("#show_options_gear").prop("checked"));

--- a/javascript/options.js
+++ b/javascript/options.js
@@ -1,5 +1,7 @@
 // Repopulate form with previously selected options
 function restoreOptions() {
+	$("#aspect_ratio_h").prop("value", localStorage.getItem("aspect_ratio_h"));
+	$("#aspect_ratio_v").prop("value", localStorage.getItem("aspect_ratio_v"));
 	$("#background_color").prop("value", localStorage.getItem("background_color"));
 	$("#custom_icon_data").prop("value", localStorage.getItem("custom_icon_data"));
 	$("#center_vertically").prop("checked", localStorage.getItem("center_vertically") === "true");
@@ -20,6 +22,8 @@ function restoreOptions() {
 
 // Write selected options back to local storage
 function saveOptions() {
+	localStorage.setItem("aspect_ratio_h", $("#aspect_ratio_h").prop("value"));
+	localStorage.setItem("aspect_ratio_v", $("#aspect_ratio_v").prop("value"));
 	localStorage.setItem("background_color", $("#background_color").prop("value"));
 	localStorage.setItem("custom_icon_data", JSON.stringify(JSON.parse($("#custom_icon_data").prop("value"))));
 	localStorage.setItem("center_vertically", $("#center_vertically").prop("checked"));
@@ -49,11 +53,56 @@ document.addEventListener("DOMContentLoaded", function() {
 	restoreOptions();
 
 	$("#save").on("click", function() {
+		var error = false;
+		function error(text, elementToFocus) {
+			alert(text);
+			error = true;
+			$(elementToFocus).focus();
+		}
 		try { // Just validate and make sure everything is good to save
 			JSON.parse($("#custom_icon_data").prop("value"));
-			saveOptions();
 		} catch (e) {
-			alert("The JSON you entered is not valid, try again.\nThe error message was: " + e);
+			error("The JSON you entered is not valid, try again.\nThe error message was: " + e, "#custom_icon_data");
+			return;
+		}
+
+		//validate aspect ratio (that it's numeric and not out of this world)
+		var aspectRH = parseFloat($("#aspect_ratio_h").prop("value"));
+		if(isNaN(aspectRH)) {
+			error("The aspect ratio you entered (first value) is not valid, try again.", "#aspect_ratio_h");
+			return;
+		}
+
+		var aspectRV = parseFloat($("#aspect_ratio_v").prop("value"));
+		if(isNaN(aspectRH)) {
+			error("The aspect ratio you entered (second value) is not valid, try again.", "#aspect_ratio_v");
+			return;
+		}
+
+		//clean up input, since '123a' is evaluated to 123, validation passes, but it certainly is NOT 123a, but 123
+		$("#aspect_ratio_h").prop("value", aspectRH);
+		$("#aspect_ratio_v").prop("value", aspectRV);
+
+		if(aspectRH==0) {
+			error("The aspect ratio you entered (first value) is zero.\nPlease enter a valid ratio (ex. 400 by 300).", "#aspect_ratio_h");
+			return;
+		}
+		if(aspectRV==0) {
+			error("The aspect ratio you entered (second value) is zero.\nPlease enter a valid ratio (ex. 400 by 300).", "#aspect_ratio_v");
+			return;
+		}
+		var aspectR = aspectRH/aspectRV;
+		if(aspectR<0.2) {
+			error("The aspect ratio you entered is less than 1 by 5.\nPlease enter a ratio that's closer to a square (ex. 400 by 300)", "#aspect_ratio_h");
+			return;
+		}
+		if(aspectR>5) {
+			error("The aspect ratio you entered is larger than 5 by 1.\nPlease enter a ratio that's closer to a square (ex. 400 by 300)", "#aspect_ratio_h");
+			return;
+		}
+
+		if(!error) {
+			saveOptions();
 		}
 	});
 	$("#cancel").on("click", function() {

--- a/javascript/options.js
+++ b/javascript/options.js
@@ -1,5 +1,7 @@
 // Repopulate form with previously selected options
 function restoreOptions() {
+	$("#aspect_ratio_h").prop("value", localStorage.getItem("aspect_ratio_h"));
+	$("#aspect_ratio_v").prop("value", localStorage.getItem("aspect_ratio_v"));
 	$("#background_color").prop("value", localStorage.getItem("background_color"));
 	$("#custom_icon_data").prop("value", localStorage.getItem("custom_icon_data"));
 	$("#center_vertically").prop("checked", localStorage.getItem("center_vertically") === "true");
@@ -20,6 +22,8 @@ function restoreOptions() {
 
 // Write selected options back to local storage
 function saveOptions() {
+	localStorage.setItem("aspect_ratio_h", $("#aspect_ratio_h").prop("value"));
+	localStorage.setItem("aspect_ratio_v", $("#aspect_ratio_v").prop("value"));
 	localStorage.setItem("background_color", $("#background_color").prop("value"));
 	localStorage.setItem("custom_icon_data", JSON.stringify(JSON.parse($("#custom_icon_data").prop("value"))));
 	localStorage.setItem("center_vertically", $("#center_vertically").prop("checked"));
@@ -49,11 +53,56 @@ document.addEventListener("DOMContentLoaded", function() {
 	restoreOptions();
 
 	$("#save").on("click", function() {
+		var isError = false;
+		function error(text, elementToFocus) {
+			alert(text);
+			isError = true;
+			$(elementToFocus).focus();
+		}
 		try { // Just validate and make sure everything is good to save
 			JSON.parse($("#custom_icon_data").prop("value"));
-			saveOptions();
 		} catch (e) {
-			alert("The JSON you entered is not valid, try again.\nThe error message was: " + e);
+			error("The JSON you entered is not valid, try again.\nThe error message was: " + e, "#custom_icon_data");
+			return;
+		}
+
+		//validate aspect ratio (that it's numeric and not out of this world)
+		var aspectRH = parseFloat($("#aspect_ratio_h").prop("value"));
+		if(isNaN(aspectRH)) {
+			error("The aspect ratio you entered (first value) is not valid, try again.", "#aspect_ratio_h");
+			return;
+		}
+
+		var aspectRV = parseFloat($("#aspect_ratio_v").prop("value"));
+		if(isNaN(aspectRH)) {
+			error("The aspect ratio you entered (second value) is not valid, try again.", "#aspect_ratio_v");
+			return;
+		}
+
+		//clean up input, since '123a' is evaluated to 123, validation passes, but it certainly is NOT 123a, but 123
+		$("#aspect_ratio_h").prop("value", aspectRH);
+		$("#aspect_ratio_v").prop("value", aspectRV);
+
+		if(aspectRH==0) {
+			error("The aspect ratio you entered (first value) is zero.\nPlease enter a valid ratio (ex. 400 by 300).", "#aspect_ratio_h");
+			return;
+		}
+		if(aspectRV==0) {
+			error("The aspect ratio you entered (second value) is zero.\nPlease enter a valid ratio (ex. 400 by 300).", "#aspect_ratio_v");
+			return;
+		}
+		var aspectR = aspectRH/aspectRV;
+		if(aspectR<0.2) {
+			error("The aspect ratio you entered is less than 1 by 5.\nPlease enter a ratio that's closer to a square (ex. 400 by 300)", "#aspect_ratio_h");
+			return;
+		}
+		if(aspectR>5) {
+			error("The aspect ratio you entered is larger than 5 by 1.\nPlease enter a ratio that's closer to a square (ex. 400 by 300)", "#aspect_ratio_h");
+			return;
+		}
+
+		if(!isError) {
+			saveOptions();
 		}
 	});
 	$("#cancel").on("click", function() {

--- a/newtab.html
+++ b/newtab.html
@@ -11,8 +11,9 @@
 
 	<body>
 		<div id="content">
+			<div id="breadcrumbs" class="innerBlock"></div>
 			<div id="folder"></div>
-			<div id="dial"></div>
+			<div id="dial" class="innerBlock"></div>
 
 			<div id="bookmark_form" class="reveal-modal">
 			     <h1></h1>

--- a/options.html
+++ b/options.html
@@ -29,6 +29,13 @@
 					</tr>
 
 					<tr>
+						<td class="field">Aspect ratio</td>
+						<td class="value">
+							<input type="text" size="6" id="aspect_ratio_h"/><span>by</span><input type="text" size="6" id="aspect_ratio_v"/>
+						</td>
+					</tr>
+
+					<tr>
 						<td class="field">Dial Width</td>
 						<td class="value">
 							<select id="dial_width">

--- a/options.html
+++ b/options.html
@@ -66,12 +66,17 @@
 					</tr>
 
 					<tr>
+						<td class="field"><label for="show_breadcrumbs">Show Breadcrumbs</label></td>
+						<td class="value"><input type="checkbox" id="show_breadcrumbs"></td>
+					</tr>
+
+					<tr>
 						<td class="field"><label for="show_folder_list">Show Folder Selector</label></td>
 						<td class="value"><input type="checkbox" id="show_folder_list"></td>
 					</tr>
 
 					<tr>
-						<td class="field"><label for="drag_and_drop">Enable Drag & Drop</label></td>
+						<td class="field"><label for="drag_and_drop">Enable Drag &amp; Drop</label></td>
 						<td class="value"><input type="checkbox" id="drag_and_drop"></td>
 					</tr>
 
@@ -123,7 +128,7 @@
 						<td class="field"><label for="custom_icon_data">Custom Icon JSON Settings</label></td>
 						<td class="value">
 							<p>This raw JSON string must be valid! <br>
-							This shows your custom icon settings so you can copy & paste between computers</p>
+							This shows your custom icon settings so you can copy &amp; paste between computers</p>
 							<textarea id="custom_icon_data" rows="4" cols="38" ></textarea>
 						</td>
 					</tr>


### PR DESCRIPTION
I have custom "icons" for the dials, that I've made, and they all use a different aspect ratio, so I needed it to work for me.

The changes include:
- New fields in the options page, with new CSS to accommodate the change (using 2 inputs in a single table cell, together with text)
- New validation rules for the inputs
- Updated HTML and CSS of the New Tab, to apply the aspect ratio on thumbnails, folders and + sign.

I had to change the way that the title is inserted, since the 4:3 ratio was used for the whole dial, and now it is used only for the thumbnail itself.

What I didn't do:
I didn't update the thumbnail service URL. It's a string, which includes ratio. I guess it should have the thumbnail size inserted automatically when you choose the service from a list.
Maybe another time.
